### PR TITLE
Fix basket cache invalidation

### DIFF
--- a/src/WebApp/Services/BasketState.cs
+++ b/src/WebApp/Services/BasketState.cs
@@ -15,8 +15,12 @@ public class BasketState(
     private Task<IReadOnlyCollection<BasketItem>>? _cachedBasket;
     private HashSet<BasketStateChangedSubscription> _changeSubscriptions = new();
 
-    public Task DeleteBasketAsync()
-        => basketService.DeleteBasketAsync();
+    public async Task DeleteBasketAsync()
+    {
+        await basketService.DeleteBasketAsync();
+        _cachedBasket = null;
+        await NotifyChangeSubscribersAsync();
+    }
 
     public async Task<IReadOnlyCollection<BasketItem>> GetBasketItemsAsync()
         => (await GetUserAsync()).Identity?.IsAuthenticated == true


### PR DESCRIPTION
## Summary
- clear cached basket and notify listeners when a basket is deleted
- remove accidental `dotnet-install.sh` script

## Testing
- `dotnet test tests/Basket.UnitTests/Basket.UnitTests.csproj -v minimal`
- `dotnet test tests/Ordering.UnitTests/Ordering.UnitTests.csproj -v minimal`
- `npx playwright test --list` *(fails: interactive install prompt)*

------
https://chatgpt.com/codex/tasks/task_e_68400f182570832b99af4c61b8c70ecc