### PR TITLE
Make prices neon green

### DIFF
--- a/src/HybridApp/Components/Pages/Item/ItemPage.razor.css
+++ b/src/HybridApp/Components/Pages/Item/ItemPage.razor.css
@@ -26,7 +26,8 @@ img {
 
 .price {
     font-size: 1.6rem;
-    font-weight: 600;
+    font-weight: bold;
+    color: #39FF14;
 }
 
 .add-to-cart button {

--- a/src/WebApp/Components/Pages/Cart/CartPage.razor.css
+++ b/src/WebApp/Components/Pages/Cart/CartPage.razor.css
@@ -110,6 +110,13 @@
     align-self: stretch;
 }
 
+.cart-summary-total div:last-child,
+.catalog-item-total,
+.price {
+    color: #39FF14;
+    font-weight: bold;
+}
+
 .cart-summary .cart-summary-link {
     display: flex;
     align-items: center;

--- a/src/WebApp/Components/Pages/Item/ItemPage.razor.css
+++ b/src/WebApp/Components/Pages/Item/ItemPage.razor.css
@@ -27,7 +27,8 @@ img {
 
 .price {
     font-size: 1.6rem;
-    font-weight: 600;
+    font-weight: bold;
+    color: #39FF14;
 }
 
 .add-to-cart button {

--- a/src/WebAppComponents/Catalog/CatalogListItem.razor.css
+++ b/src/WebAppComponents/Catalog/CatalogListItem.razor.css
@@ -40,11 +40,11 @@
 }
 
 .catalog-product-content .price {
-    color: #444;
+    color: #39FF14;
     text-align: right;
     font-size: 1rem;
     font-style: normal;
-    font-weight: 600;
+    font-weight: bold;
     line-height: 150%;
     margin-left: auto;
 }


### PR DESCRIPTION
## Summary
- update catalog list item price style
- make item page price text neon green
- apply the same styling to hybrid app
- style cart prices, totals and summary

## Testing
- `dotnet test --no-build` *(fails: `dotnet` not found)*
- `npm test` *(fails: `npm` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6863d71d9bcc832b9349be3854ee06ab