### PR TITLE
New Validation Logic

### DIFF
--- a/src/Basket.API/Model/BasketItem.cs
+++ b/src/Basket.API/Model/BasketItem.cs
@@ -19,6 +19,11 @@ public class BasketItem : IValidatableObject
             results.Add(new ValidationResult("Invalid number of units", new[] { "Quantity" }));
         }
 
+        if (OldUnitPrice >= UnitPrice)
+        {
+            results.Add(new ValidationResult("Der Preis ist zu heiß!", new[] { "OldUnitPrice", "UnitPrice" }));
+        }
+
         return results;
     }
 }


### PR DESCRIPTION
This pull request introduces a validation improvement to the `BasketItem` model in the `Basket.API` project. It adds a new condition to ensure that the `OldUnitPrice` is not greater than or equal to the `UnitPrice`.

Validation improvements:

* [`src/Basket.API/Model/BasketItem.cs`](diffhunk://#diff-845968b9e96fcc10d3e2edbfef80c811cd40fafd8708edaab3b86d873efe9486R22-R26): Added a validation check to the `Validate` method that triggers an error message ("Der Preis ist zu heiß!") if `OldUnitPrice` is greater than or equal to `UnitPrice`.