### PR TITLE
Add dark mode theme toggle

### DIFF
--- a/src/WebApp/Components/App.razor
+++ b/src/WebApp/Components/App.razor
@@ -9,11 +9,20 @@
     <link rel="stylesheet" href="css/app.css" />
     <link rel="stylesheet" href="WebApp.styles.css" />
     <link rel="shortcut icon" href="images/favicon.png" />
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme');
+            if (theme === 'dark') {
+                document.documentElement.classList.add('dark');
+            }
+        })();
+    </script>
     <HeadOutlet />
 </head>
 
 <body>
     <Routes />
+    <script src="js/theme.js"></script>
     <script src="_framework/blazor.web.js"></script>
 </body>
 

--- a/src/WebApp/Components/Layout/HeaderBar.razor
+++ b/src/WebApp/Components/Layout/HeaderBar.razor
@@ -15,6 +15,7 @@
             
             <UserMenu />
             <CartMenu />
+            <button id="theme-toggle" class="theme-toggle" aria-label="Toggle dark mode">🌓</button>
         </nav>
         <div class="eshop-header-intro">
             <h1><SectionOutlet SectionName="page-header-title" /></h1>

--- a/src/WebApp/Components/Layout/HeaderBar.razor.css
+++ b/src/WebApp/Components/Layout/HeaderBar.razor.css
@@ -111,6 +111,14 @@
     }
 }
 
+.theme-toggle {
+    background: none;
+    border: none;
+    cursor: pointer;
+    font-size: 1.25rem;
+    color: inherit;
+}
+
 @media only screen and (min-width: 481px) and (max-width: 1024px) { 
     .eshop-header.home .eshop-header-hero {
         height: 24rem;
@@ -148,4 +156,11 @@
     .eshop-header-intro p {
         font-size: 1.5rem;
     }
+}
+.theme-toggle {
+    background: none;
+    border: none;
+    cursor: pointer;
+    font-size: 1.25rem;
+    color: inherit;
 }

--- a/src/WebApp/wwwroot/css/app.css
+++ b/src/WebApp/wwwroot/css/app.css
@@ -289,3 +289,16 @@ h1:focus {
     .blazor-error-boundary::after {
         content: "An error has occurred."
     }
+html.dark {
+    filter: invert(1) hue-rotate(180deg);
+    background-color: #121212;
+    color-scheme: dark;
+}
+
+html.dark img,
+html.dark video,
+html.dark picture,
+html.dark svg,
+html.dark iframe {
+    filter: invert(1) hue-rotate(180deg);
+}

--- a/src/WebApp/wwwroot/js/theme.js
+++ b/src/WebApp/wwwroot/js/theme.js
@@ -1,0 +1,9 @@
+(() => {
+  const toggle = document.getElementById('theme-toggle');
+  if (!toggle) return;
+  toggle.addEventListener('click', () => {
+    document.documentElement.classList.toggle('dark');
+    const mode = document.documentElement.classList.contains('dark') ? 'dark' : 'light';
+    localStorage.setItem('theme', mode);
+  });
+})();


### PR DESCRIPTION
## Summary
- add dark-mode support using CSS inversion
- add header toggle to switch between dark and light themes

## Testing
- `dotnet build src/WebApp -c Release`
- `dotnet test tests/Basket.UnitTests -c Release`
- `dotnet test tests/ClientApp.UnitTests -c Release` *(fails: NETSDK1147 missing workloads)*

------
https://chatgpt.com/codex/tasks/task_e_68baeecb11f8832b95f7d27130fd4852