### PR TITLE
Add rounded styling and hover shadows to product images

### DIFF
--- a/src/WebApp/Components/Pages/Cart/CartPage.razor.css
+++ b/src/WebApp/Components/Pages/Cart/CartPage.razor.css
@@ -60,6 +60,13 @@
 .cart-items .cart-item .catalog-item-info img {
     max-height: 12rem;
     max-width: 12rem;
+    border-radius: 0.75rem;
+    box-shadow: 0 0.5rem 1.5rem rgba(0, 0, 0, 0.08);
+    transition: box-shadow 0.2s ease;
+}
+
+.cart-items .cart-item .catalog-item-info img:hover {
+    box-shadow: 0 1rem 2.5rem rgba(0, 0, 0, 0.12);
 }
 
 .cart-summary-container {

--- a/src/WebApp/Components/Pages/Item/ItemPage.razor.css
+++ b/src/WebApp/Components/Pages/Item/ItemPage.razor.css
@@ -10,9 +10,16 @@ p:first-of-type {
     margin-top: 0;
 }
 
-img {
+.item-details img {
     width: 25rem;
     max-width: 50%;
+    border-radius: 0.75rem;
+    box-shadow: 0 0.75rem 2rem rgba(0, 0, 0, 0.1);
+    transition: box-shadow 0.2s ease;
+}
+
+.item-details img:hover {
+    box-shadow: 0 1.25rem 3rem rgba(0, 0, 0, 0.18);
 }
 
 .description {

--- a/src/WebAppComponents/Catalog/CatalogListItem.razor.css
+++ b/src/WebAppComponents/Catalog/CatalogListItem.razor.css
@@ -20,6 +20,13 @@
 
 .catalog-product-image img {
     max-width: 100%;
+    border-radius: 0.75rem;
+    box-shadow: 0 0.5rem 1.5rem rgba(0, 0, 0, 0.08);
+    transition: box-shadow 0.2s ease;
+}
+
+.catalog-item:hover .catalog-product-image img {
+    box-shadow: 0 1rem 2.5rem rgba(0, 0, 0, 0.12);
 }
 
 .catalog-product .catalog-product-content {


### PR DESCRIPTION
## Summary
- add consistent rounded corners and base shadows to catalog, cart, and item detail product images
- introduce hover shadows that expand subtly when item photos are focused

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dbe52a4bcc832baedf0db98bc52ac7