### PR TITLE
Add confetti animation when adding items to the basket

### DIFF
--- a/src/WebApp/Components/App.razor
+++ b/src/WebApp/Components/App.razor
@@ -14,6 +14,8 @@
 
 <body>
     <Routes />
+    <script src="https://cdn.jsdelivr.net/npm/canvas-confetti@1.6.0/dist/confetti.browser.min.js" integrity="sha384-yPBtd6aAvjJEOmQoMePNgm6kKiC9JIhbSAVnX1nvUs61f7oTWJPfm6D/EjV116I0" crossorigin="anonymous"></script>
+    <script src="js/confetti.js"></script>
     <script src="_framework/blazor.web.js"></script>
 </body>
 

--- a/src/WebApp/Components/Pages/Item/ItemPage.razor
+++ b/src/WebApp/Components/Pages/Item/ItemPage.razor
@@ -3,6 +3,7 @@
 @inject CatalogService CatalogService
 @inject BasketState BasketState
 @inject NavigationManager Nav
+@inject IJSRuntime JS
 @inject IProductImageUrlProvider ProductImages
 
 @if (item is not null)
@@ -99,6 +100,7 @@ else if (notFound)
         {
             await BasketState.AddAsync(item);
             await UpdateNumInCartAsync();
+            await TriggerConfettiAsync();
         }
     }
 
@@ -106,5 +108,17 @@ else if (notFound)
     {
         var items = await BasketState.GetBasketItemsAsync();
         numInCart = items.FirstOrDefault(row => row.ProductId == ItemId)?.Quantity ?? 0;
+    }
+
+    private async Task TriggerConfettiAsync()
+    {
+        try
+        {
+            await JS.InvokeVoidAsync("eshopConfetti.launch");
+        }
+        catch (JSDisconnectedException)
+        {
+            // If the connection has been interrupted, there's nowhere to display confetti.
+        }
     }
 }

--- a/src/WebApp/wwwroot/js/confetti.js
+++ b/src/WebApp/wwwroot/js/confetti.js
@@ -1,0 +1,39 @@
+window.eshopConfetti = window.eshopConfetti || {
+    launch: () => {
+        if (typeof confetti !== "function") {
+            return;
+        }
+
+        const duration = 2000;
+        const animationEnd = Date.now() + duration;
+        const defaults = {
+            spread: 360,
+            ticks: 180,
+            gravity: 0.8,
+            decay: 0.94,
+            startVelocity: 60,
+            zIndex: 1000,
+            scalar: 1.2,
+        };
+
+        const randomInRange = (min, max) => Math.random() * (max - min) + min;
+
+        const shoot = () => {
+            confetti({
+                ...defaults,
+                particleCount: 180,
+                origin: { x: randomInRange(0.1, 0.9), y: randomInRange(0.1, 0.3) },
+                colors: ["#ff577f", "#ff884b", "#ffd384", "#fff9b0", "#62cdff", "#8c52ff"],
+            });
+        };
+
+        const frame = () => {
+            shoot();
+            if (Date.now() < animationEnd) {
+                requestAnimationFrame(frame);
+            }
+        };
+
+        frame();
+    },
+};


### PR DESCRIPTION
## Summary
- load a reusable canvas-confetti helper for the web storefront
- trigger the helper from the item page whenever an add-to-basket succeeds

## Testing
- dotnet build src/WebApp/WebApp.csproj

------
https://chatgpt.com/codex/tasks/task_e_68de84b84e84832ba96ce95d23b33b98